### PR TITLE
Checking that we pass along the authentication header

### DIFF
--- a/islandora-indexing-triplestore/src/test/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexerTest.java
+++ b/islandora-indexing-triplestore/src/test/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexerTest.java
@@ -188,9 +188,11 @@ public class TriplestoreIndexerTest extends CamelBlueprintTestSupport {
 
         endpoint.expectedMessageCount(1);
         endpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
+        endpoint.expectedHeaderReceived("Authentication", "some_nifty_token");
 
         template.send(exchange -> {
             exchange.setProperty("uri", "http://localhost:8000/fedora_resource/1");
+            exchange.getIn().setHeader("Authentication", "some_nifty_token");
         });
 
         assertMockEndpointsSatisfied();


### PR DESCRIPTION
Hey, patched up the tests to assert incoming message structure in tests.  One less sinkhole for you on this grand adventure.